### PR TITLE
chore: remove jpa related configs from application.yml for MyBatis migration

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,14 +5,6 @@ spring:
   application:
     name: fraud-detection-system
 
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-
 server:
   port: 8080
 


### PR DESCRIPTION
## Summary
- Removed jpa related configs from application.yml
- From this project I am planning to use MyBatis instead of JPA.

## Modified
- `application.yml`